### PR TITLE
Forgot password

### DIFF
--- a/API/Controllers/AuthController.cs
+++ b/API/Controllers/AuthController.cs
@@ -1,7 +1,11 @@
-﻿using Application.Users.Commands.LoginUser;
+﻿using Application.Interface;
+using Application.Users.Commands.ForgotPassword;
+using Application.Users.Commands.LoginUser;
 using Application.Users.Commands.RefreshToken;
+using Application.Users.Commands.ResetPassword;
 using Application.Users.Dtos;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace API.Controllers
@@ -45,5 +49,29 @@ namespace API.Controllers
 
             return Ok(result.Value);
         }
+        
+        [HttpPost("forgot-password")]
+        [AllowAnonymous] // Alla ska kunna nå denna även utan att vara inloggade
+        public async Task<IActionResult> ForgotPassword([FromBody] ForgotPasswordRequest request)
+        {
+            var result = await _mediator.Send(new ForgotPasswordCommand(request.Email));
+
+            // Vi returnerar alltid 200 OK med ett generellt meddelande
+            return Ok(new { message = "If an account with that email exists, we have sent a reset link." });
+        }
+        
+        [HttpPost("reset-password")]
+        public async Task<IActionResult> ResetPassword([FromBody] ResetPasswordRequest request)
+        {
+            var result = await _mediator.Send(new ResetPasswordCommand(request.Token, request.NewPassword));
+
+            if (!result.IsSuccess)
+            {
+                return BadRequest(result.ErrorMessage);
+            }
+
+            return Ok(new { message = "Password has been successfully reset." });
+        }
+
     }
 }

--- a/Application/Interface/IUserRepository.cs
+++ b/Application/Interface/IUserRepository.cs
@@ -16,5 +16,10 @@ namespace Application.Interface
         Task<RefreshToken?> GetRefreshTokenAsync(string token, CancellationToken cancellationToken = default);
         
         Task UpdateRefreshTokenAsync(RefreshToken refreshToken, CancellationToken cancellationToken = default);
+        
+        Task<User?> GetByResetTokenAsync(string token, CancellationToken cancellationToken = default);
+        
+        Task UpdateUserAsync(User user, CancellationToken cancellationToken = default);
+        
     }
 }

--- a/Application/Interface/ResetPasswordRequest.cs
+++ b/Application/Interface/ResetPasswordRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace Application.Interface
+{
+    public record ResetPasswordRequest
+    (
+        string Token,
+        string NewPassword
+    );
+}

--- a/Application/Users/Commands/ForgotPassword/ForgotPasswordCommand.cs
+++ b/Application/Users/Commands/ForgotPassword/ForgotPasswordCommand.cs
@@ -1,0 +1,7 @@
+﻿using Application.Common;
+using MediatR;
+
+namespace Application.Users.Commands.ForgotPassword
+{
+    public record ForgotPasswordCommand(string Email) : IRequest<OperationResult<bool>>;
+}

--- a/Application/Users/Commands/ForgotPassword/ForgotPasswordHandler.cs
+++ b/Application/Users/Commands/ForgotPassword/ForgotPasswordHandler.cs
@@ -1,0 +1,42 @@
+﻿using System.Security.Cryptography;
+using Application.Common;
+using Application.Interface;
+using MediatR;
+
+namespace Application.Users.Commands.ForgotPassword
+{
+    public class ForgotPasswordHandler : IRequestHandler<ForgotPasswordCommand, OperationResult<bool>>
+    {
+        private readonly IUserRepository _repository;
+        
+        public ForgotPasswordHandler(IUserRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<OperationResult<bool>> Handle(ForgotPasswordCommand request,
+            CancellationToken cancellationToken)
+        {
+            var user = await _repository.GetByEmailAsync(request.Email);
+
+            if (user == null)
+            {
+                return OperationResult<bool>.Success(true);
+            }
+
+            var resetToken = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
+            
+            user.ResetPasswordToken = resetToken;
+            user.ResetTokenExpires = DateTime.UtcNow.AddHours(1);
+            
+            await _repository.SaveChangesAsync(cancellationToken);
+            
+               // TODO: Här ska IEmailService anropas i framtiden.
+            // Just nu lägger vi t.ex. logga token till konsolen för att kunna testa:
+            
+            Console.WriteLine($"DEBUG:Reset token for {user.Email}: {resetToken}");
+            
+            return OperationResult<bool>.Success(true);
+        }
+    }
+}

--- a/Application/Users/Commands/ResetPassword/ResetPasswordCommand.cs
+++ b/Application/Users/Commands/ResetPassword/ResetPasswordCommand.cs
@@ -1,0 +1,7 @@
+﻿using Application.Common;
+using MediatR;
+
+namespace Application.Users.Commands.ResetPassword
+{
+    public record ResetPasswordCommand(string Token, string NewPassword): IRequest<OperationResult<bool>>;
+}

--- a/Application/Users/Commands/ResetPassword/ResetPasswordHandler.cs
+++ b/Application/Users/Commands/ResetPassword/ResetPasswordHandler.cs
@@ -1,0 +1,38 @@
+﻿using Application.Common;
+using Application.Interface;
+using MediatR;
+
+namespace Application.Users.Commands.ResetPassword
+{
+    public class ResetPasswordHandler : IRequestHandler<ResetPasswordCommand, OperationResult<bool>>
+    {
+        private readonly IUserRepository _userRepository;
+        private readonly IPasswordHasher _passwordHasher;
+        
+        public ResetPasswordHandler(IUserRepository userRepository, IPasswordHasher passwordHasher)
+        {
+            _userRepository = userRepository;
+            _passwordHasher = passwordHasher;
+        }
+
+        public async Task<OperationResult<bool>> Handle(ResetPasswordCommand request,
+            CancellationToken cancellationToken)
+        {
+            var user = await _userRepository.GetByResetTokenAsync(request.Token, cancellationToken);
+            
+            if (user == null || user.ResetTokenExpires < DateTime.UtcNow)
+            {
+                return OperationResult<bool>.Failure("Invalid or expired reset token.");
+            }
+            
+            user.PasswordHash = _passwordHasher.HashPassword(request.NewPassword);
+            
+            user.ResetPasswordToken = null;
+            user.ResetTokenExpires = null;
+            
+            await _userRepository.UpdateUserAsync(user, cancellationToken);
+            
+            return OperationResult<bool>.Success(true);
+        }
+    }
+}

--- a/Application/Users/Dtos/ForgotPasswordRequest.cs
+++ b/Application/Users/Dtos/ForgotPasswordRequest.cs
@@ -1,0 +1,4 @@
+﻿namespace Application.Users.Dtos
+{
+    public record ForgotPasswordRequest(string Email);
+}

--- a/Domain/Models/User.cs
+++ b/Domain/Models/User.cs
@@ -13,6 +13,7 @@ namespace Domain.Models
         public DateTime? DateOfBirth { get; set; }
         public UserRole Role { get; set; } 
         public DateTime CreatedAt { get; set; }
+        
 
         // Navigation - User can own multiple businesses
         public ICollection<Business> Businesses { get; set; } = new List<Business>();

--- a/Domain/Models/User.cs
+++ b/Domain/Models/User.cs
@@ -14,6 +14,8 @@ namespace Domain.Models
         public UserRole Role { get; set; } 
         public DateTime CreatedAt { get; set; }
         
+        public string? ResetPasswordToken { get; set; }
+        public DateTime? ResetTokenExpires { get; set; }
 
         // Navigation - User can own multiple businesses
         public ICollection<Business> Businesses { get; set; } = new List<Business>();

--- a/Infrastructure/Migrations/20260121145818_AddPasswordResetFields.Designer.cs
+++ b/Infrastructure/Migrations/20260121145818_AddPasswordResetFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260121145818_AddPasswordResetFields")]
+    partial class AddPasswordResetFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Infrastructure/Migrations/20260121145818_AddPasswordResetFields.cs
+++ b/Infrastructure/Migrations/20260121145818_AddPasswordResetFields.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPasswordResetFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ResetPasswordToken",
+                table: "users",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ResetTokenExpires",
+                table: "users",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ResetPasswordToken",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "ResetTokenExpires",
+                table: "users");
+        }
+    }
+}

--- a/Infrastructure/Repositories/UserRepository.cs
+++ b/Infrastructure/Repositories/UserRepository.cs
@@ -63,5 +63,22 @@ namespace Infrastructure.Repositories
             
             return _context.SaveChangesAsync(cancellationToken);
         }
+
+        public async Task<User?> GetByResetTokenAsync(string token, CancellationToken cancellationToken = default)
+        {
+            var normalizedToken = token.Trim().ToUpper();
+            
+            
+            return await _context.Users
+                .FirstOrDefaultAsync(u => u.ResetPasswordToken != null && 
+                                          u.ResetPasswordToken.Trim().ToUpper() == normalizedToken, 
+                    cancellationToken);
+        }
+
+        public  Task UpdateUserAsync(User user, CancellationToken cancellationToken = default)
+        {
+            _context.Users.Update(user);
+            return _context.SaveChangesAsync(cancellationToken);
+        }
     }
 }

--- a/Tests/Unit/Auth/AuthControllerTest.cs
+++ b/Tests/Unit/Auth/AuthControllerTest.cs
@@ -1,9 +1,11 @@
 ﻿using API.Controllers;
 using Application.Common;
-using Application.Users.Commands.CreateUser;
+using Application.Interface;
+using Application.Users.Commands.ForgotPassword;
+using Application.Users.Commands.LoginUser;
+using Application.Users.Commands.RefreshToken;
+using Application.Users.Commands.ResetPassword;
 using Application.Users.Dtos;
-using Application.Users.Queries.GetCurrentUser;
-using Domain.Enum; // Krävs för UserRole
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
@@ -11,66 +13,127 @@ using Xunit;
 
 namespace Tests.UnitTests.Controllers
 {
-    public class UserControllerTests
+    public class AuthControllerTests
     {
         private readonly Mock<IMediator> _mediatorMock;
-        private readonly UserController _controller;
+        private readonly AuthController _controller;
 
-        public UserControllerTests()
+        public AuthControllerTests()
         {
             _mediatorMock = new Mock<IMediator>();
-            _controller = new UserController(_mediatorMock.Object);
+            _controller = new AuthController(_mediatorMock.Object);
         }
 
+        #region Login Tests
         [Fact]
-        public async Task Register_ShouldReturnCreated_WhenCommandSucceeds()
-        {
-            // Arrange - Skicka in argument i parentesen för Primary Constructor
-            var command = new CreateUserCommand(
-                "test@test.se", 
-                "Password123", 
-                "Mikael", 
-                "Persson", 
-                "0701234567", 
-                DateTime.Now.AddYears(-25), 
-                UserRole.User
-            );
-
-            var userDto = new UserDto(
-                Guid.NewGuid(), 
-                "test@test.se", 
-                "Mikael", 
-                "Persson", 
-                "0701234567", 
-                DateTime.Now.AddYears(-25), 
-                UserRole.User.ToString(), // Om DTO:n förväntar sig sträng här
-                DateTime.Now
-            );
-            
-            _mediatorMock.Setup(m => m.Send(command, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(OperationResult<UserDto>.Success(userDto));
-
-            // Act
-            var result = await _controller.Register(command);
-
-            // Assert
-            var createdAtActionResult = Assert.IsType<CreatedAtActionResult>(result);
-            Assert.Equal(201, createdAtActionResult.StatusCode);
-        }
-
-        [Fact]
-        public async Task GetCurrentProfile_ShouldReturnUnauthorized_WhenUserNotLoggedIn()
+        public async Task Login_ShouldReturnOk_WhenCredentialsAreValid()
         {
             // Arrange
-            _mediatorMock.Setup(m => m.Send(It.IsAny<GetCurrentUserQuery>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(OperationResult<UserDto>.Failure("Användaren är inte inloggad.")); // Detta triggar 401
+            var command = new LoginCommand("test@test.se", "Password123");
+            var loginResponse = new LoginResponseDto(
+                "fake-jwt-token",
+                "fake-refresh-token",
+                DateTime.Now.AddDays(7),
+                new UserDto(Guid.NewGuid(), "test@test.se", "Mikael", "Daskalou", "070", DateTime.Now, "Admin", DateTime.Now)
+            );
+
+            _mediatorMock.Setup(m => m.Send(command, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(OperationResult<LoginResponseDto>.Success(loginResponse));
 
             // Act
-            var result = await _controller.GetCurrentProfile();
+            var result = await _controller.Login(command);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(200, okResult.StatusCode);
+            Assert.Equal(loginResponse, okResult.Value);
+        }
+
+        [Fact]
+        public async Task Login_ShouldReturnUnauthorized_WhenCredentialsAreInvalid()
+        {
+            // Arrange
+            var command = new LoginCommand("wrong@test.se", "WrongPass");
+            _mediatorMock.Setup(m => m.Send(command, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(OperationResult<LoginResponseDto>.Failure("Invalid email or password."));
+
+            // Act
+            var result = await _controller.Login(command);
 
             // Assert
             var unauthorizedResult = Assert.IsType<UnauthorizedObjectResult>(result);
             Assert.Equal(401, unauthorizedResult.StatusCode);
         }
+        #endregion
+
+        #region Refresh Token Tests
+        [Fact]
+        public async Task RefreshToken_ShouldReturnOk_WhenTokenIsValid()
+        {
+            // Arrange
+            var request = new RefreshTokenRequest("valid-refresh-token");
+            var loginResponse = new LoginResponseDto("new-jwt", "new-refresh", DateTime.Now, null!);
+
+            _mediatorMock.Setup(m => m.Send(It.IsAny<RefreshTokenCommand>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(OperationResult<LoginResponseDto>.Success(loginResponse));
+
+            // Act
+            var result = await _controller.RefreshToken(request);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(200, okResult.StatusCode);
+        }
+        #endregion
+
+        #region Forgot/Reset Password Tests
+        [Fact]
+        public async Task ForgotPassword_ShouldAlwaysReturnOk_ForPrivacy()
+        {
+            // Arrange
+            var request = new ForgotPasswordRequest("any@email.com");
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ForgotPasswordCommand>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(OperationResult<bool>.Success(true));
+
+            // Act
+            var result = await _controller.ForgotPassword(request);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(200, okResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task ResetPassword_ShouldReturnOk_WhenTokenIsCorrect()
+        {
+            // Arrange
+            var request = new ResetPasswordRequest("valid-token", "NewPassword123!");
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ResetPasswordCommand>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(OperationResult<bool>.Success(true));
+
+            // Act
+            var result = await _controller.ResetPassword(request);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(200, okResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task ResetPassword_ShouldReturnBadRequest_WhenTokenIsExpired()
+        {
+            // Arrange
+            var request = new ResetPasswordRequest("expired-token", "NewPassword123!");
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ResetPasswordCommand>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(OperationResult<bool>.Failure("Invalid or expired reset token."));
+
+            // Act
+            var result = await _controller.ResetPassword(request);
+
+            // Assert
+            var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal(400, badRequestResult.StatusCode);
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
This pull request introduces a complete password reset feature to the authentication system, including backend logic, API endpoints, data model changes, and corresponding unit tests. The implementation allows users to request a password reset link and reset their password securely using a token. In addition, the user entity and database schema are updated to support password reset tokens. The most important changes are grouped below:

**Password Reset Feature Implementation:**

* Added `ForgotPassword` and `ResetPassword` endpoints to `AuthController`, allowing users to request a password reset and to reset their password using a token. The endpoints always return a generic message for privacy and handle token validation and password updates.
* Implemented `ForgotPasswordCommand`/`Handler` to generate a secure reset token, store it with an expiry in the user record, and (for now) log it to the console.
* 
* Implemented `ResetPasswordCommand`/`Handler` to validate the reset token, update the user's password, and clear the reset token fields. 
* 
* Added request DTOs for forgot and reset password flows (`ForgotPasswordRequest`, `ResetPasswordRequest`). 

**User Entity, Repository, and Persistence Changes:**

* Extended the `User` model with `ResetPasswordToken` and `ResetTokenExpires` fields, and updated the database schema via a new migration and model snapshot. 
* Updated `IUserRepository` and its implementation to support fetching users by reset token and updating user records. 

**Testing:**

* Added and refactored unit tests in `AuthControllerTest.cs` to cover login, refresh token, forgot password, and reset password scenarios, including success and failure cases.